### PR TITLE
updates for grid.odata.js plugin

### DIFF
--- a/plugins/grid.odata.js
+++ b/plugins/grid.odata.js
@@ -19,6 +19,7 @@
      *    beforeInitGrid: function () {           //can be also put at: onInitGrid
      *        $(this).jqGrid('odataInit', {
      *            version: 4,
+     *            gencolumns: false,
      *            odataurl: 'http://localhost:56216/odata/ODClient'
      *        });
      *    }
@@ -31,6 +32,7 @@
      *            version: 4,
      *            async: false,
      *            gencolumns: true,
+     *            entityType: 'ClientModel',
      *            odataurl: 'http://localhost:56216/odata/ODClient',
      *            metadataurl: 'http://localhost:56216/odata/$metadata'
      *        });
@@ -145,7 +147,7 @@
                     //$inlinecount: "allpages" //- not relevant for V4
                 };
 
-                if (o.datatype === 'jsonp') { params.$callback = o.callback; }
+                //if (o.datatype === 'jsonp') { params.$callback = o.callback; }
                 if (o.count) { params.$count = true; }
                 if (o.top) { params.$top = postData.rows; }
                 if (o.inlinecount) { params.$inlinecount = "allpages"; }
@@ -180,6 +182,11 @@
             }
 
             function initDefaults(p, o) {
+                var defaultAjaxOptions = {
+                    contentType: 'application/' + o.datatype + ';charset=utf-8',
+                    datatype: o.datatype
+                };
+
                 p.inlineEditing = $.extend(true, {
                     beforeSaveRow: function (options, rowid, frmoper) {
                         if (options.extraparam.oper === 'edit') {
@@ -197,10 +204,7 @@
                     serializeSaveData: function (postdata) {
                         return JSON.stringify(postdata);
                     },
-                    ajaxSaveOptions: {
-                        contentType: 'application/json;charset=utf-8',
-                        datatype: 'json'
-                    }
+                    ajaxSaveOptions: defaultAjaxOptions
                 }, p.inlineEditing || {});
 
                 $.extend(p.formEditing, {
@@ -216,10 +220,7 @@
 
                         return postdata;
                     },
-                    ajaxEditOptions: {
-                        contentType: 'application/json;charset=utf-8',
-                        datatype: 'json'
-                    },
+                    ajaxEditOptions: defaultAjaxOptions,
                     serializeEditData: function (postdata) {
                         return JSON.stringify(postdata);
                     }
@@ -235,10 +236,7 @@
                         options.url += '(' + postdata + ')';
                         return '';
                     },
-                    ajaxDelOptions: {
-                        contentType: 'application/json;charset=utf-8',
-                        datatype: 'json'
-                    }
+                    ajaxDelOptions: defaultAjaxOptions
                 });
 
                 $.extend(p, {
@@ -246,55 +244,62 @@
                         postData = setupWebServiceData(p, o, postData);
                         return postData;
                     },
-                    ajaxGridOptions: {
-                        contentType: "application/json;charset=utf-8",
-                        datatype: 'json'
-                    },
-                    datatype: o.datatype,
-                    jsonpCallback: o.callback,
-                    contentType: "application/json;charset=utf-8",
+                    ajaxGridOptions: defaultAjaxOptions,                   
+                    //jsonpCallback: o.callback,
                     mtype: 'GET',
                     url: o.odataurl
-                });
+                }, defaultAjaxOptions);
 
-                if (o.annotations) {
-                    $.extend(true, p, {
-                        loadBeforeSend: function (jqXHR) {
-                            jqXHR.setRequestHeader("Prefer", 'odata.include-annotations="*"');
-                        },
-                        jsonReader: {
-                            root: "value",
-                            repeatitems: false,
-                            records: function (data) { return data[o.annotationName].records; },
-                            page: function (data) { return data[o.annotationName].page; },
-                            total: function (data) { return data[o.annotationName].total; },
-                            userdata: function (data) { return data[o.annotationName].userdata; }
-                        }
-                    });
+                if (o.datatype === 'xml') {
+                    if (o.annotations) {
+                        $.extend(true, p, {
+                            loadBeforeSend: function (jqXHR) {
+                                jqXHR.setRequestHeader("Prefer", 'odata.include-annotations="*"');
+                            },
+                            //xmlReader: { ??? }
+                        });
+                    }
                 }
                 else {
-                    $.extend(true, p, {
-                        jsonReader: {
-                            root: "value",
-                            repeatitems: false,
-                            records: "odata.count",
-                            page: function (data) {
-                                if (data["odata.nextLink"] !== undefined) {
-                                    var skip = data["odata.nextLink"].split('skip=')[1];
-                                    return Math.ceil(parseInt(skip, 10) / p.rowNum);
-                                }
+                    if (o.annotations) {
+                        $.extend(true, p, {
+                            loadBeforeSend: function (jqXHR) {
+                                jqXHR.setRequestHeader("Prefer", 'odata.include-annotations="*"');
+                            },
+                            jsonReader: {
+                                root: "value",
+                                repeatitems: false,
+                                records: function (data) { return data[o.annotationName].records; },
+                                page: function (data) { return data[o.annotationName].page; },
+                                total: function (data) { return data[o.annotationName].total; },
+                                userdata: function (data) { return data[o.annotationName].userdata; }
+                            }
+                        });
+                    }
+                    else {
+                        $.extend(true, p, {
+                            jsonReader: {
+                                root: "value",
+                                repeatitems: false,
+                                records: "odata.count",
+                                page: function (data) {
+                                    if (data["odata.nextLink"] !== undefined) {
+                                        var skip = data["odata.nextLink"].split('skip=')[1];
+                                        return Math.ceil(parseInt(skip, 10) / p.rowNum);
+                                    }
 
-                                var total = data["odata.count"];
-                                return Math.ceil(parseInt(total, 10) / p.rowNum);
-                            },
-                            total: function (data) {
-                                var total = data["odata.count"];
-                                return Math.ceil(parseInt(total, 10) / p.rowNum);
-                            },
-                            userdata: "userdata"
-                        }
-                    });
-                }
+                                    var total = data["odata.count"];
+                                    return Math.ceil(parseInt(total, 10) / p.rowNum);
+                                },
+                                total: function (data) {
+                                    var total = data["odata.count"];
+                                    return Math.ceil(parseInt(total, 10) / p.rowNum);
+                                },
+                                userdata: "userdata"
+                            }
+                        });
+                    }
+                }         
             }
 
             return this.each(function () {
@@ -302,10 +307,13 @@
                 if (!$t.grid || !p) { return; }
 
                 var o = $.extend(true, {
-                    datatype: 'json',	//json,jsonp
                     gencolumns: false,
-                    odataurl: p.url
+                    odataurl: p.url,
+                    datatype: 'json'     //json,xml
                 }, options || {});
+
+                //xml dataType is not supported
+                o.datatype = 'json';
 
                 if (!o.version || o.version < 4) {
                     o = $.extend(true, {
@@ -326,14 +334,15 @@
                     }, o || {});
                 }
 
-                if (o.datatype === 'jsonp') { o.callback = "jsonCallback_" + $.jgrid.randId(); }
+                //if (o.datatype === 'jsonp') { o.callback = "jsonCallback_" + $.jgrid.randId(); }
                 if (o.gencolumns) {
                     var gencol = $.extend(true, {
                         parsecolfunc: null,
                         parsemetadatafunc: null,
-                        errorfunc: null,
                         successfunc: null,
+                        errorfunc: null,
                         async: false,
+                        entityType: null,
                         metadataurl: (options.odataurl || p.url) + '/$metadata'
                     }, options || {});
 
@@ -361,72 +370,199 @@
                 parsemetadatafunc: null, 
                 successfunc: null, 
                 errorfunc: null,
+                entityType: null,
                 metadataurl: p.url + '/$metadata',
+                datatype: 'json',           //json,xml
                 async: false
             }, options || {});
+
+            if(!o.entityType) {
+                if($.isFunction(o.errorfunc)) { o.errorfunc({}, 'entityType cannot be empty', 0); }
+                return;
+            }
 
             $.ajax({
                 url: o.metadataurl,
                 type: 'GET',
-                dataType: 'xml',
+                dataType: o.datatype,
+                contentType: 'application/' + o.datatype + ';charset=utf-8',
                 async: o.async,
                 cache: false
             })
             .done(function (data, st, xhr) {
-                var i = 0, j = 0;
-                var newcol = $self.triggerHandler("jqGridODataParseMetadata", data);
+                var i = 0, j = 0, isInt, isNum, isDate;
+                var intTypes = 'Edm.Byte,Edm.Int16,Edm.Int32,Edm.Int64,Edm.SByte';
+                var numTypes = 'Edm.Decimal,Edm.Double,Edm.Single';
 
+                if (o.datatype === 'json') { data = resolveReferences(data); }
+                var newcol = $self.triggerHandler("jqGridODataParseMetadata", data);
                 if (newcol === undefined && $.isFunction(o.parsemetadatafunc)) { newcol = o.parsemetadatafunc(data, st, xhr); }
                 if (newcol === undefined) {
-                    //var xmldata = $.parseXML(xhr.responseText);
-                    var props = $('EntityType[Name!="Default"] Property', data);
-                    var keys = $('EntityType[Name!="Default"] Key PropertyRef', data);
-                    if (props.length > 0) {
-                        var key = keys.length>0 ? keys.first().attr('Name') : '';
-                        
-                        var cols = [];
-                        props.each(function (n, itm) {
-                            var name = $(itm).attr('Name');
-                            var type = $(itm).attr('Type').replace('Edm.', '');
-                            var nullable = $(itm).attr('Nullable');
-                            var iskey = (name === key);
-
-                            cols.push({ name: name, type: type, nullable: nullable, iskey: iskey });
-                        });
-
-                        if (cols.length === 0) {
-                            if ($.isFunction(o.errorfunc)) { o.errorfunc(xhr, 'parse $metadata error', 0); }
-                        }
-
+                    var cols = o.datatype === 'xml' ? parseXmlData(data, o.entityType) : parseJsonData(data, o.entityType);
+                    if (cols.length === 0) {
+                        if ($.isFunction(o.errorfunc)) { o.errorfunc({data: data, status: st, xhr: xhr}, 'parse $metadata error', 0); }
+                    }
+                    else {
                         newcol = $self.triggerHandler("jqGridODataParseColumns", cols);
                         if (newcol === undefined && $.isFunction(o.parsecolfunc)) { newcol = o.parsecolfunc(cols); }
                         if (newcol === undefined) {
                             newcol = [];
                             for (i = 0; i < cols.length; i++) {
-                                newcol.push({ label: cols[i].name, name: cols[i].name, index: cols[i].name, editable: !cols[i].iskey });
+                                isInt = intTypes.indexOf(cols[i].type) >= 0;
+                                isNum = numTypes.indexOf(cols[i].type) >= 0;
+                                isDate = cols[i].type.indexOf('Edm.') >= 0 && (cols[i].type.indexOf('Date') >= 0 || cols[i].type.indexOf('Time') >= 0);
+                                newcol.push({
+                                    label: cols[i].name,
+                                    name: cols[i].name,
+                                    index: cols[i].name,
+                                    editable: !cols[i].iskey,
+                                    searchrules: { integer: isInt, number: isNum, datetime: isDate },
+                                    editrules: { integer: isInt, number: isNum, datetime: isDate }
+                                });
                             }
                         }
                     }
                 }
 
-                for (i = 0; i < p.colModel.length; i++) {
-                    for (j = 0; j < newcol.length; j++) {
-                        if (newcol[j].name === p.colModel[i].name) {
-                            $.extend(true, newcol[j], p.colModel[i]);
-                            break;
+                if (newcol) {
+                    for (i = 0; i < p.colModel.length; i++) {
+                        for (j = 0; j < newcol.length; j++) {
+                            if (newcol[j].name === p.colModel[i].name) {
+                                $.extend(true, newcol[j], p.colModel[i]);
+                                if (p.colModel[i].searchrules) {
+                                    newcol[j].searchrules = p.colModel[i].searchrules;
+                                }
+                                if (p.colModel[i].editrules) {
+                                    newcol[j].editrules = p.colModel[i].editrules;
+                                }
+                                break;
+                            }
                         }
                     }
-                }
-                p.colModel = newcol;
+                    p.colModel = newcol;
 
-                if ($.isFunction(o.successfunc)) {
-                    o.successfunc();
+                    if ($.isFunction(o.successfunc)) {
+                        o.successfunc();
+                    }
                 }
+                else {
+                    if ($.isFunction(o.errorfunc)) { o.errorfunc({ data: data, status: st, xhr: xhr }, 'parse $metadata error', 0); }
+                }                               
             })
             .fail(function (xhr, err, code) {
                 if ($.isFunction(o.errorfunc)) { o.errorfunc(xhr, err, code); }
             });
-        }
 
+            function parseXmlData(data, entityType) {
+                var cols = [], props, keys, key, name, type, nullable, iskey;
+
+                //var xmldata = $.parseXML(xhr.responseText);
+                props = $('EntityType[Name="' + entityType + '"] Property', data);
+                keys = $('EntityType[Name="' + entityType + '"] Key PropertyRef', data);
+
+                key = keys && keys.length > 0 ? keys.first().attr('Name') : '';
+                if (props) {
+                    props.each(function (n, itm) {
+                        name = $(itm).attr('Name');
+                        type = $(itm).attr('Type');
+                        nullable = $(itm).attr('Nullable');
+                        iskey = (name === key);
+
+                        cols.push({ name: name, type: type, nullable: nullable, iskey: iskey });
+                    });
+                }
+
+                return cols;
+            }
+
+            //http:// stackoverflow.com/questions/15312529/resolve-circular-references-from-json-object
+            function resolveReferences(json) {
+                if (typeof json === 'string')
+                    json = JSON.parse(json);
+
+                var byid = {}, // all objects by id
+                    refs = []; // references to objects that could not be resolved
+                json = (function recurse(obj, prop, parent) {
+                    if (typeof obj !== 'object' || !obj) // a primitive value
+                        return obj;
+                    if (Object.prototype.toString.call(obj) === '[object Array]') {
+                        for (var i = 0; i < obj.length; i++) {
+                            // check also if the array element is not a primitive value
+                            if (typeof obj[i] !== 'object' || !obj[i]) // a primitive value
+                                return obj[i];
+                            else if ("$ref" in obj[i])
+                                obj[i] = recurse(obj[i], i, obj);
+                            else
+                                obj[i] = recurse(obj[i], prop, obj);
+                        }
+                        return obj;
+                    }
+                    if ("$ref" in obj) { // a reference
+                        var ref = obj.$ref;
+                        if (ref in byid)
+                            return byid[ref];
+                        // else we have to make it lazy:
+                        refs.push([parent, prop, ref]);
+                        return;
+                    } else if ("$id" in obj) {
+                        var id = obj.$id;
+                        delete obj.$id;
+                        if ("$values" in obj) // an array
+                            obj = obj.$values.map(recurse);
+                        else {// a plain object
+                            for (var prop in obj) {
+                                obj[prop] = recurse(obj[prop], prop, obj);
+                            }
+                        }
+                        byid[id] = obj;
+                    }
+                    return obj;
+                })(json); // run it!
+
+                for (var i = 0; i < refs.length; i++) { // resolve previously unknown references
+                    var ref = refs[i];
+                    ref[0][ref[1]] = byid[ref[2]];
+                    // Notice that this throws if you put in a reference at top-level
+                }
+                return json;
+            }
+
+            function parseJsonData(data, entityType) {
+                var cols = [], props, keys, key, name, type, nullable, iskey, i, j;
+                var schemaElements = (data.SchemaElements.$values || data.SchemaElements);
+                for (i = 0; i < schemaElements.length ; i++) {
+                    if (schemaElements[i].Name === o.entityType) {
+                        props = schemaElements[i].DeclaredProperties.$values || schemaElements[i].DeclaredProperties;
+                        keys = schemaElements[i].DeclaredKey.$values || schemaElements[i].DeclaredKey;
+                        break;
+                    }
+                }
+
+                key = keys && keys.length > 0 ? keys[0].Name : '';
+                if (props) {
+                    for (i = 0; i < props.length; i++) {
+                        if (props[i].$ref) {
+                            cols.push({ name: props[i].$ref, type: null, nullable: false, iskey: false });
+                        }
+                        else {
+                            name = props[i].Name;
+                            iskey = (name === key);
+                            nullable = props[i].Type.IsNullable;
+
+                            if (props[i].Type.Definition.$ref) {
+                                type = props[i].Type.Definition.$ref;
+                            }
+                            else {
+                                type = props[i].Type.Definition.Namespace + '.' + props[i].Type.Definition.Name;
+                            }
+
+                            cols.push({ name: name, type: type, nullable: nullable, iskey: iskey });
+                        }
+                    }
+                }
+
+                return cols;
+            }
+        }
     });
 }(jQuery));


### PR DESCRIPTION
removed support for **jsonp** dataType because it wasn't checked thoroughly and it interfers with **json** dataType.
removed support for $metadata **xml** dataType because the main flow doesn't support **xml** dataType yet and there is no reason use xml for $metadata alone.
added support for $metadata **json** dataType including both **PreserveReferencesHandling.All** and **PreserveReferencesHandling.Object**
added support for **searchrules/editrules** when generating colModels from $metadata
added mandatory field  **entityType** to generate correctly colModels from $metadata