### PR TITLE
Update jquery.jqgrid.src.js

### DIFF
--- a/js/jquery.jqgrid.src.js
+++ b/js/jquery.jqgrid.src.js
@@ -11982,9 +11982,6 @@
 							viewModal("#" + jqID(alertIDs.themodal), { gbox: gboxSelector, toTop: o.alertToTop, jqm: o.jqModal });
 							var $close = $("#" + jqID(alertIDs.modalhead)).find(".ui-jqdialog-titlebar-close");
 							$close.attr({ tabindex: "0", href: "#", role: "button" });
-							setTimeout(function () {
-								$close.focus(); //$(p.idSel + "_jqg_alrt").focus();
-							}, 50);
 						};
 					},
 					viewModalAlert = createModalAlert(),


### PR DESCRIPTION
Deleted code led to focus on "x" close icon in alert modal popup and display blue "outline" around it (tested in Chrome).
For example, it appears when you try to bulk delete rows, but no rows are selected (dialog alerts with message "Please, select rows").

The problem can be also solved by deletion of this line (one line above):
$close.attr({ tabindex: "0", href: "#", role: "button" });

But if grid needs these attributes it is good idea to delete focus trigger as I suggested, because I don't see any benefits of focusing of "close" icon. Thanks!