### PR TITLE
Updated bootstrap styling for the "loading" mesage

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -669,7 +669,7 @@
 				gBox: "ui-jqgrid-bootstrap",
 				gView: "panel-info",
 				overlay: "modal-backdrop",
-				loading: "",
+				loading: "alert alert-info",
 				hDiv: "",
 				hTable: "table table-hover table-condensed table-bordered",
 				colHeaders: "",


### PR DESCRIPTION
The current styling displays the "loading" message (displayed when the grid data is being retrieved from the server) as an unstyled text.
With this pull request you get the data displayed in small box in the color "info" (which you can customize in your bootstrap theme).