### PR TITLE
Updated find call

### DIFF
--- a/js/jquery.jqgrid.src.js
+++ b/js/jquery.jqgrid.src.js
@@ -1247,11 +1247,11 @@
 			}
 			switch (componentName) {
 				case COMPONENT_NAMES.BODY_TABLE: // get body table from bDiv
-					return $p.hasClass("ui-jqgrid-bdiv") ? $p.find(">div>.ui-jqgrid-btable") : $();
-				case COMPONENT_NAMES.HEADER_TABLE: // header table from bDiv
-					return $p.hasClass("ui-jqgrid-hdiv") ? $p.find(">div>.ui-jqgrid-htable") : $();
-				case COMPONENT_NAMES.FOOTER_TABLE: // footer/summary table from sDiv
-					return $p.hasClass("ui-jqgrid-sdiv") ? $p.find(">div>.ui-jqgrid-ftable") : $();
+	                    		return $p.hasClass("ui-jqgrid-bdiv") ? $p.find(".ui-jqgrid-btable") : $();
+	                	case COMPONENT_NAMES.HEADER_TABLE: // header table from bDiv
+	                    		return $p.hasClass("ui-jqgrid-hdiv") ? $p.find(".ui-jqgrid-htable") : $();
+	                	case COMPONENT_NAMES.FOOTER_TABLE: // footer/summary table from sDiv
+	                    		return $p.hasClass("ui-jqgrid-sdiv") ? $p.find(".ui-jqgrid-ftable") : $();
 				case COMPONENT_NAMES.FROZEN_HEADER_TABLE: // header table from bDiv
 					return $p.hasClass("ui-jqgrid-hdiv") ? $p.children(".ui-jqgrid-htable") : $();
 				case COMPONENT_NAMES.FROZEN_FOOTER_TABLE: // footer/summary table from sDiv


### PR DESCRIPTION
In microsoft edge $p.find(">div>.ui-jqgrid-btable") is very slow.
if I change the call in $p.find(".ui-jqgrid-btable") the function is much faster.
I found it because in my grid I call the autoresizeall columns, and in edge it was very slow (the loading time was about 6 seconds) than in chrome (the loading time was about 2 seconds instead).
Changing the call, edge reached the same loading time of chrome.
I think that also in chrome there is a very small boost, but I'm not sure.