### PR TITLE
Zeros for cell value do not sort correctly for sorttype of int

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -1798,7 +1798,7 @@
 							};
 						} else if (type === "int" || type === "integer") {
 							findSortKey = function ($cell) {
-								return $cell ? parseFloat(String($cell).replace(_stripNum, "")) : Number.NEGATIVE_INFINITY;
+								return $cell !== undefined && $cell !== null ? parseFloat(String($cell).replace(_stripNum, "")) : Number.NEGATIVE_INFINITY;
 							};
 						} else if (type === "date" || type === "datetime") {
 							findSortKey = function ($cell) {


### PR DESCRIPTION
When a cell had a value of zero, when checking $cell, the zero value was being evaluated as false and Number.NEGATIVE_INFINITY was being used as the sort.