### PR TITLE
If editoptions.defaultValue is a function, call it with options

### DIFF
--- a/js/grid.inlinedit.js
+++ b/js/grid.inlinedit.js
@@ -538,7 +538,7 @@
 					$(p.colModel).each(function () {
 						if (this.editoptions && this.editoptions.defaultValue) {
 							var opt = this.editoptions.defaultValue;
-							o.initdata[this.name] = $.isFunction(opt) ? opt.call($t) : opt;
+							o.initdata[this.name] = $.isFunction(opt) ? opt.call($t,o) : opt;
 						}
 					});
 				}


### PR DESCRIPTION
If editoptions.defaultValue is a function, call it with options so that a value based on the current edit can be returned. Just like e.g. in onInlineAdd.