### PR TITLE
reloadGrid fails because of p not initialized.

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -5898,7 +5898,7 @@
 					// the usage of return false break checking/uchecking
 				})
 				.on("reloadGrid", function (e, opts) {
-					var self = this, gridSelf = self.grid, $self = $(this);
+					var self = this, p = self.p, gridSelf = self.grid, $self = $(this);
 					if (p.treeGrid === true) {
 						p.datatype = p.treedatatype;
 					}

--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -5898,7 +5898,8 @@
 					// the usage of return false break checking/uchecking
 				})
 				.on("reloadGrid", function (e, opts) {
-					var self = this, p = self.p, gridSelf = self.grid, $self = $(this);
+					var self = this, gridSelf = self.grid, $self = $(this);
+					p = self.p; 
 					if (p.treeGrid === true) {
 						p.datatype = p.treedatatype;
 					}


### PR DESCRIPTION
Property p is not correctly initialized.